### PR TITLE
fix(contexts): fix wrong `updateType` when `mergeMediaEvents` is used

### DIFF
--- a/packages/puregram/src/contexts/mixins/clone.ts
+++ b/packages/puregram/src/contexts/mixins/clone.ts
@@ -15,6 +15,7 @@ class CloneMixin<C extends Context & Constructor<C>, Options extends Record<stri
       payload: this.payload,
       updateId: this.updateId as number,
       update: this.update as TelegramUpdate,
+      type: this.updateType,
       ...options
     })
   }


### PR DESCRIPTION
## The bug
When the `mergeMediaEvents` option is used, any possible merge media event `(message, edited_message, channel_post, edited_channel_post)` returns the resulting context with the `message` type.

![image](https://user-images.githubusercontent.com/46501450/197366557-194515e4-d858-4285-8e8c-c1d05078e403.png)

## The solution
This is the most elegant and practical solution I could find. I simply added an override of the `type` field in the `clone` method of `CloneMixin`:

https://github.com/tangenx/puregram/blob/6441bb3b0f59427d8acc4858f33ec56110d40e54/packages/puregram/src/contexts/mixins/clone.ts#L18

...and it worked!