### PR TITLE
fix: add puregram package support links

### DIFF
--- a/packages/puregram/package.json
+++ b/packages/puregram/package.json
@@ -60,6 +60,10 @@
     "url": "https://github.com/puregram/puregram",
     "directory": "packages/puregram"
   },
+  "homepage": "https://github.com/puregram/puregram/tree/v3/packages/puregram#readme",
+  "bugs": {
+    "url": "https://github.com/puregram/puregram/issues"
+  },
   "keywords": [
     "telegram",
     "telegram-api",


### PR DESCRIPTION
## Summary
- adds npm `homepage` metadata for the `puregram` package
- adds `bugs.url` metadata pointing to the public issue tracker

## Validation
- `node` metadata assertion for `homepage`, `bugs.url`, and repository directory
- `npm pack --dry-run --json` from `packages/puregram`
- `git diff --check`

This keeps the package metadata aligned with the existing repository metadata and makes the npm package page link to the package docs and issue tracker.
